### PR TITLE
Add markdown-only index endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-t
 # Gianfranco Palumbo ― Personal Website and Blog
 
 This is my personal website, built with **Astro** and **TypeScript**. It serves as my digital home and will eventually include a microblog.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+t
 # Gianfranco Palumbo ― Personal Website and Blog
 
 This is my personal website, built with **Astro** and **TypeScript**. It serves as my digital home and will eventually include a microblog.

--- a/src/pages/index.md.ts
+++ b/src/pages/index.md.ts
@@ -8,7 +8,6 @@ Software developer obsessed with AI—LLMs, TTS, agents, bots, and the intersect
 ## Navigation
 
 - [Blog](/blog)
-// - [About](/about)
 
 ## Links
 

--- a/src/pages/index.md.ts
+++ b/src/pages/index.md.ts
@@ -1,0 +1,31 @@
+import type { APIRoute } from "astro";
+
+export const GET: APIRoute = async () => {
+  const markdownContent = `# Gianfranco Palumbo (@gianpaj)
+
+Software developer obsessed with AI—LLMs, TTS, agents, bots, and the intersection of creativity and automation. Building tools and exploring the frontier where code meets intelligence.
+
+## Navigation
+
+- [Blog](/blog)
+- [Projects](/projects)
+- [About](/about)
+
+## Links
+
+- GitHub: [@gianpaj](https://github.com/gianpaj)
+- Twitter: [@gianpaj](https://twitter.com/gianpaj)
+- Email: gianpa.spain@gmail.com
+
+---
+
+*This is the markdown-only version of gian.cool. Visit [gian.cool](https://gian.cool) for the full experience.*`;
+
+  return new Response(markdownContent, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, max-age=3600",
+    },
+  });
+};

--- a/src/pages/index.md.ts
+++ b/src/pages/index.md.ts
@@ -8,14 +8,12 @@ Software developer obsessed with AI—LLMs, TTS, agents, bots, and the intersect
 ## Navigation
 
 - [Blog](/blog)
-- [Projects](/projects)
-- [About](/about)
+// - [About](/about)
 
 ## Links
 
 - GitHub: [@gianpaj](https://github.com/gianpaj)
 - Twitter: [@gianpaj](https://twitter.com/gianpaj)
-- Email: gianpa.spain@gmail.com
 
 ---
 


### PR DESCRIPTION
Add a new `index.md.ts` endpoint that serves a markdown-only version of the homepage, similar to the steipete.me implementation.

This provides a plain text markdown view of the site at `/index.md` with basic site info, navigation, and social links.